### PR TITLE
Refactor/meshinst init

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleActor.cpp
@@ -30,21 +30,18 @@ void AParticleActor::PostSpawnInitialize()
 
     // TypeDataModule 생성 및 세팅 (현재는 Sprite Type이라고 가정하고 일단 아래처럼 구현)
     UParticleModuleTypeDataSprite* SpriteTypeData = FObjectFactory::ConstructObject<UParticleModuleTypeDataSprite>(nullptr);
-    SpriteTypeData->bEnabled = true;
 
+    /* [NOTE!!!] 모든 Module은 생성자에서 bEnabled = true */
     // Location 모듈 생성
     UParticleModuleLocation* LocMod = FObjectFactory::ConstructObject<UParticleModuleLocation>(nullptr);
-    LocMod->bEnabled = true;
-    LocMod->StartLocation = FVector::ZeroVector;  // 하드코딩
+    //LocMod->StartLocation = FVector::ZeroVector;  // 하드코딩
 
     // Velocity 모듈 생성
     UParticleModuleVelocity* VelMod = FObjectFactory::ConstructObject<UParticleModuleVelocity>(nullptr);
-    VelMod->bEnabled = true;
     //VelMod->StartVelocity = FVector(0.f, 0.f, 1.f);  // 하드코딩
 
     // Lifetime 모듈 생성
     UParticleModuleLifeTime* LifeMod = FObjectFactory::ConstructObject<UParticleModuleLifeTime>(nullptr);
-    LifeMod->bEnabled = true;
 
 
     // TODO : (원한다면 파생 클래스로 교체: UParticleModuleTypeDataSprite 등)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleActor.cpp
@@ -5,6 +5,7 @@
 #include "ParticleSystem.h"
 #include "ParticleEmitter.h"
 #include "ParticleLODLevel.h"
+#include "ParticleModuleLifeTime.h"
 #include "ParticleModuleLocation.h"
 #include "TypeData/ParticleModuleTypeDataBase.h"
 #include "ParticleModuleVelocity.h"
@@ -40,7 +41,11 @@ void AParticleActor::PostSpawnInitialize()
     UParticleModuleVelocity* VelMod = FObjectFactory::ConstructObject<UParticleModuleVelocity>(nullptr);
     VelMod->bEnabled = true;
     //VelMod->StartVelocity = FVector(0.f, 0.f, 1.f);  // 하드코딩
-    
+
+    // Lifetime 모듈 생성
+    UParticleModuleLifeTime* LifeMod = FObjectFactory::ConstructObject<UParticleModuleLifeTime>(nullptr);
+    LifeMod->bEnabled = true;
+
 
     // TODO : (원한다면 파생 클래스로 교체: UParticleModuleTypeDataSprite 등)
 
@@ -51,8 +56,8 @@ void AParticleActor::PostSpawnInitialize()
     LOD->RequiredModule = ReqMod;
     LOD->TypeDataModule = SpriteTypeData;
 
-    LOD->Modules = { ReqMod, SpriteTypeData, LocMod, VelMod };
-    LOD->SpawnModules = { ReqMod, SpriteTypeData, LocMod, VelMod };  // Spawn 시에만 위치+속도 세팅
+    LOD->Modules = { ReqMod, SpriteTypeData, LocMod, VelMod, LifeMod };
+    LOD->SpawnModules = { ReqMod, SpriteTypeData, LocMod, VelMod, LifeMod };  // Spawn 시에만 위치+속도 세팅
     LOD->UpdateModules = { SpriteTypeData };
 
     // Offset/Size 계산

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleActor.cpp
@@ -16,6 +16,7 @@ void AParticleActor::PostSpawnInitialize()
     Super::PostSpawnInitialize();
 
     ParticleSystemComponent = AddComponent<UParticleSystemComponent>(FName("ParticleSystemComponent_0"));
+    RootComponent = ParticleSystemComponent;
 
     // -- 1) PS / Emitter / LOD 생성
     UParticleSystem* PS = FObjectFactory::ConstructObject<UParticleSystem>(this);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
@@ -3,6 +3,8 @@
 #include "ParticleHelper.h"
 #include "ParticleLODLevel.h"
 #include "ParticleModule.h"
+#include "TypeData/ParticleModuleTypeDataMesh.h"
+#include "ParticleEmitterInstances.h"
 
 UParticleLODLevel* UParticleEmitter::GetLODLevel(int32 LODLevel)
 {
@@ -26,6 +28,33 @@ void UParticleEmitter::Build()
         UE_LOG(ELogLevel::Error, TEXT("ParticleSize=%d  ReqInstanceBytes=%d Modules=%d"),
             ParticleSize, ReqInstanceBytes, ModulesNeedingInstanceData.Num());
     }
+}
+
+/**
+ * @param InComponent 
+ * @return 어떤 타입의 EmitterInstance 를 만들지 결정하여 반환
+ */
+FParticleEmitterInstance* UParticleEmitter::CreateInstance(UParticleSystemComponent* InComponent)
+{
+    
+    const UParticleModuleTypeDataBase* TypeDataMod = LODLevels[0]->TypeDataModule;
+    FParticleEmitterInstance* NewInst = nullptr;
+
+    /* TODO : Beam2 등의 확장 필요 */
+    if (TypeDataMod && TypeDataMod->IsA(UParticleModuleTypeDataMesh::StaticClass()))
+    {
+        NewInst = new FParticleMeshEmitterInstance();
+    }
+    else
+    {
+        NewInst = new FParticleSpriteEmitterInstance();
+    }
+
+    // 2) 공통 포인터 설정
+    NewInst->Component = InComponent;
+    NewInst->SpriteTemplate = this;
+
+    return NewInst;
 }
 
 /*

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.h
@@ -6,6 +6,7 @@
 #include "Container/Array.h"
 
 class UParticleLODLevel;
+class UParticleSystemComponent;
 
 enum class EEmitterRenderMode : int
 {
@@ -37,8 +38,6 @@ struct FParticleBurst
 
 };
 
-
-
 class UParticleEmitter : public UObject
 {
     DECLARE_CLASS(UParticleEmitter, UObject)
@@ -46,6 +45,7 @@ class UParticleEmitter : public UObject
 public:
     UParticleEmitter() = default;
     void Build();
+    FParticleEmitterInstance* CreateInstance(UParticleSystemComponent* InComponent);
     void CacheEmitterModuleInfo();
     void PostLoad();
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitterInstances.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitterInstances.cpp
@@ -339,7 +339,7 @@ float FParticleEmitterInstance::Spawn(float DeltaTime)
     FVector Origin = Component->GetWorldLocation() + CurrentLODLevel->RequiredModule->EmitterOrigin;
     const FVector InitialVelocity = FVector::ZeroVector;
 
-    // SpawnTime 분배: 균일 분포
+    // SpawnTime 균등 분배
     const float Increment = (Rate > 0.f) ? (1.f / Rate) : 0.f;
     float StartTime = DeltaTime + SpawnFraction * Increment - Increment;
 
@@ -384,9 +384,9 @@ void FParticleEmitterInstance::PreSpawn(FBaseParticle* Particle, const FVector& 
     // 생명 시간
     Particle->RelativeTime = 0.0f;
     float& Lifetime = CurrentLODLevel->RequiredModule->EmitterDuration;
-    Particle->OneOverMaxLifetime = Lifetime > 0.f
-        ? 1.f / (Lifetime * 2)// TODO (TOFIX!) : 임의로 duration만큼 살아있게 함
-        : 1.f;
+    //Particle->OneOverMaxLifetime = Lifetime > 0.f
+    //    ? 1.f / (Lifetime * 2)// TODO (TOFIX!) : 임의로 duration만큼 살아있게 함
+    //    : 1.f;
     // 생명 6배, 6개 동시존재가능
 }
 
@@ -438,6 +438,10 @@ void FParticleEmitterInstance::SpawnParticles(int32 Count, float StartTime, floa
          DECLARE_PARTICLE_PTR(Particle, ParticleData + (ParticleStride * DataIdx));
 
          // 언리얼에선 bLegacySpawnBehavior가 true일때 아래와 같이 반영
+         /* SpawnTime < 0 : 과거에 생성되었어야 하는 파티클
+          * 균등 분포된 다수의 파티클 생성 시, 각 파티클을 프레임 시간 내에서 일정 간격으로 배치하기 위함
+          * 한 프레임에 10개 생성 : 
+          */
          SpawnTime -= Increment;
          Interp -= InterpDelta;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitterInstances.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitterInstances.h
@@ -43,7 +43,8 @@ struct FParticleEmitterInstance
     /** 파티클 배열 내 최대 활성화 개수 **/
     int32 MaxActiveParticles;
 
-    float SpawnFraction;
+    /* ex) 지난 프레임에서 생성해야 했던 파티클의 소수점 개수*/
+    float SpawnFraction; 
     float EmitterTime;
     float LastDeltaTime;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitterInstances.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitterInstances.h
@@ -3,6 +3,7 @@
 #include "HAL/PlatformType.h"
 #include "ParticleHelper.h"
 
+class UParticleModuleTypeDataMesh;
 class UParticleEmitter;
 class UParticleSystemComponent;
 class UParticleLODLevel;
@@ -52,6 +53,7 @@ struct FParticleEmitterInstance
     uint8 bEnabled : 1;
 
     FParticleEmitterInstance();
+    virtual ~FParticleEmitterInstance() = default;
 
     // 각 Emitter Type에 맞게 오버라이딩 필요
     virtual FDynamicEmitterDataBase* GetDynamicData(bool bSelected);
@@ -83,4 +85,30 @@ struct FParticleEmitterInstance
     virtual bool Resize(int32 NewMaxActiveParticles, bool bSetMaxActiveCount = true);
     virtual void Rewind();
     virtual void UpdateBoundingBox(float DeltaTime);
+};
+
+
+struct FParticleMeshEmitterInstance : public FParticleEmitterInstance
+{
+    using Super = FParticleEmitterInstance;
+public:
+    FParticleMeshEmitterInstance() = default;
+
+    virtual void Init(UParticleSystemComponent* InComponent, int32 InEmitterIndex) override;
+    virtual FDynamicEmitterDataBase* GetDynamicData(bool bSelected) override;
+    virtual bool FillReplayData(FDynamicEmitterReplayDataBase& OutData) override;
+
+    /* 매번 Cast하지 않고, LODLevel 의 TypeDataModule을 캐싱하는 용도 */
+    UParticleModuleTypeDataMesh* MeshTypeData;
+};
+
+struct FParticleSpriteEmitterInstance : public FParticleEmitterInstance
+{
+    using Super = FParticleEmitterInstance;
+public:
+    FParticleSpriteEmitterInstance() = default;
+
+    virtual void Init(UParticleSystemComponent* InComponent, int32 InEmitterIndex) override;
+    virtual FDynamicEmitterDataBase* GetDynamicData(bool bSelected) override;
+    virtual bool FillReplayData(FDynamicEmitterReplayDataBase& OutData) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleHelper.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleHelper.h
@@ -137,7 +137,7 @@ struct FBaseParticle
 
     // 16 bytes
     float			RelativeTime;			// Relative time, range is 0 (==spawn) to 1 (==death). RelativeTime >= 1.0f 이면 Kill. RelativeTime += DeltaTime / LifeTime.
-    float			OneOverMaxLifetime;		// Reciprocal of lifetime. 1 / Lifetime 계산을 매번 하지 않기 위한 캐시 값.
+    float			OneOverMaxLifetime;		// 1초당 늘어날 수명 = 1/MaxLifeTime [0, 1]
     float			Placeholder0;
     float			Placeholder1;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleHelper.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleHelper.h
@@ -849,13 +849,15 @@ struct FDynamicSpriteEmitterDataBase : public FDynamicEmitterDataBase
 
 struct FDynamicSpriteEmitterData : public FDynamicSpriteEmitterDataBase
 {
+public:
+
     FDynamicSpriteEmitterData(const UParticleModuleRequired* RequiredModule) :
         FDynamicSpriteEmitterDataBase(RequiredModule)
     {
     }
     ~FDynamicSpriteEmitterData() {}
 
-    void Init(bool bInSelected);
+    virtual void Init(bool bInSelected);
     
     virtual int32 GetDynamicVertexStride(/*ERHIFeatureLevel::Type InFeatureLevel*/) const override // ERHIFeatureLevel::Type 은 렌더 플랫폼에 관련된 정보이므로 필요 없음.
     {
@@ -889,20 +891,14 @@ struct FDynamicSpriteEmitterData : public FDynamicSpriteEmitterDataBase
 };
 
 
-/** Dynamic emitter data for Mesh emitters */
-struct FDynamicMeshEmitterData : public FDynamicSpriteEmitterDataBase
+/** Dynamic emitter data for Mesh emitters
+ * SpriteEmitterDataBase를 상속받는 이유 : 기본 Sprite인 상태에서 Mesh 추가하는 듯
+ */
+struct FDynamicMeshEmitterData : public FDynamicSpriteEmitterData /* 야매 : FDynamicSpriteEmitterDataBase*/
 {
     FDynamicMeshEmitterData(const UParticleModuleRequired* RequiredModule);
 
-    virtual ~FDynamicMeshEmitterData();
-
-    /** Initialize this emitter's dynamic rendering data, called after source data has been filled in */
-    void Init(bool bInSelected,
-        const FParticleMeshEmitterInstance* InEmitterInstance,
-        UStaticMesh* InStaticMesh,
-        bool InUseStaticMeshLODs,
-        float InLODSizeScale
-        /*ERHIFeatureLevel::Type InFeatureLevel*/);
+    virtual void Init(bool bInSelected) override;
 
     void CalculateParticleTransform(
         const FMatrix& ProxyLocalToWorld,
@@ -919,9 +915,6 @@ struct FDynamicMeshEmitterData : public FDynamicSpriteEmitterDataBase
         FMatrix& OutTransformMat
     ) const;
 
-    /**
-     *	Get the vertex stride for the dynamic rendering data
-     */
     virtual int32 GetDynamicVertexStride(/*ERHIFeatureLevel::Type*/ /*InFeatureLevel*/) const override
     {
         return sizeof(FMeshParticleInstanceVertex);
@@ -932,9 +925,6 @@ struct FDynamicMeshEmitterData : public FDynamicSpriteEmitterDataBase
         return sizeof(FMeshParticleInstanceVertexDynamicParameter);
     }
 
-    /**
-     *	Get the source replay data for this emitter
-     */
     virtual const FDynamicSpriteEmitterReplayDataBase* GetSourceData() const override
     {
         return &Source;
@@ -946,38 +936,20 @@ struct FDynamicMeshEmitterData : public FDynamicSpriteEmitterDataBase
         return Source;
     }
 
-    /** The frame source data for this particle system.  This is everything needed to represent this
-        this particle system frame.  It does not include any transient rendering thread data.  Also, for
-        non-simulating 'replay' particle systems, this data may have come straight from disk! */
-    FDynamicMeshEmitterReplayData Source;
-
-    int32					LastFramePreRendered;
-
     UStaticMesh* StaticMesh;
-    //TArray<FMaterialRenderProxy*, TInlineAllocator<2>> MeshMaterials;
 
-    /** offset to FMeshTypeDataPayload */
+    FDynamicMeshEmitterReplayData SourceMesh; // 야매코드 : Source여야 함
+
+    int32 LastFramePreRendered;
+
+
     uint32 MeshTypeDataOffset;
 
-    // 'orientation' items...
-    // These don't need to go into the replay data, as they are constant over the life of the emitter
-    /** If true, apply the 'pre-rotation' values to the mesh. */
     uint32 bApplyPreRotation : 1;
-    /** If true, then use the locked axis setting supplied. Trumps locked axis module and/or TypeSpecific mesh settings. */
     uint32 bUseMeshLockedAxis : 1;
-    /** If true, then use the camera facing options supplied. Trumps all other settings. */
     uint32 bUseCameraFacing : 1;
-    /**
-     *	If true, apply 'sprite' particle rotation about the orientation axis (direction mesh is pointing).
-     *	If false, apply 'sprite' particle rotation about the camera facing axis.
-     */
     uint32 bApplyParticleRotationAsSpin : 1;
-    /**
-    *	If true, all camera facing options will point the mesh against the camera's view direction rather than pointing at the cameras location.
-    *	If false, the camera facing will point to the cameras position as normal.
-    */
     uint32 bFaceCameraDirectionRatherThanPosition : 1;
-    /** The EMeshCameraFacingOption setting to use if bUseCameraFacing is true. */
     uint8 CameraFacingOption;
 
     bool bUseStaticMeshLODs;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.cpp
@@ -2,6 +2,21 @@
 
 #include "UObject/Casts.h"
 #include "ParticleEmitterInstances.h"
+#include "Distributions/DistributionFloatUniform.h"
+#include "UObject/ObjectFactory.h"
+
+
+/* LifeTime 값 초기화 */
+void UParticleModuleLifeTime::PostInitProperties()
+{
+    Super::PostInitProperties();
+    LifeTime.Distribution = FObjectFactory::ConstructObject<UDistributionFloatUniform>(this);
+    if (auto* Dist = Cast<UDistributionFloatUniform>(LifeTime.Distribution))
+    {
+        Dist->Min = 3.f;
+        Dist->Max = 10.f;
+    }
+}
 
 void UParticleModuleLifeTime::Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase)
 {
@@ -11,6 +26,7 @@ void UParticleModuleLifeTime::Spawn(FParticleEmitterInstance* Owner, int32 Offse
     if (Particle.OneOverMaxLifetime > 0.0f)
     {
         // 다른 모듈이 이미 LifeTime을 설정한 경우, MaxLifeTime을 조정하여 OneOverMaxLifetime을 유지.
+        // 두 수명을 병합 : 더 작은 수명을 우선시하며 혼합
         Particle.OneOverMaxLifetime = 1.0f / (MaxLifeTime + 1.f / Particle.OneOverMaxLifetime);
     }
     else
@@ -20,4 +36,5 @@ void UParticleModuleLifeTime::Spawn(FParticleEmitterInstance* Owner, int32 Offse
     }
 
     Particle.RelativeTime = Particle.RelativeTime > 1.0f ? Particle.RelativeTime : SpawnTime * Particle.OneOverMaxLifetime;
+
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.h
@@ -15,7 +15,4 @@ public:
 
 	virtual void PostInitProperties() override;
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase);
-
-
-    
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.h
@@ -13,7 +13,8 @@ public:
 
     UPROPERTY(EditAnywhere, FRawDistributionFloat, LifeTime)
 
-    virtual void	Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase);
+	virtual void PostInitProperties() override;
+    virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase);
 
 
     

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.h
@@ -9,7 +9,7 @@ class UParticleModuleLifeTime : public UParticleModuleLifeTimeBase
     DECLARE_CLASS(UParticleModuleLifeTime, UParticleModuleLifeTimeBase)
 
 public:
-    UParticleModuleLifeTime() = default;
+    UParticleModuleLifeTime();
 
     UPROPERTY(EditAnywhere, FRawDistributionFloat, LifeTime)
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLocation.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLocation.h
@@ -1,16 +1,18 @@
 #pragma once
 
 #include "ParticleModuleLocationBase.h"
+#include "Distributions/DistributionVector.h"
 
 class UParticleModuleLocation : public UParticleModuleLocationBase
 {
     DECLARE_CLASS(UParticleModuleLocation, UParticleModuleLocationBase)
 
 public:
-    UParticleModuleLocation() = default;
+    UParticleModuleLocation();
+    virtual void PostInitProperties() override;
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;
 
 
-    FVector StartLocation;
+    FRawDistributionVector StartLocation;
 
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleRequired.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleRequired.h
@@ -25,6 +25,9 @@ struct FParticleRequiredModule
     uint8 bUseVelocityForMotionBlur : 1;
 };
 
+/* 렌더링에 필요한 공통 파라미터(머티리얼, 색상, 정렬, Facing 등)을 정의
+ * 모든 EmitterInstance를 상속받는 모든 클래스의 생성자에 인자로 들어감
+ */
 
 class UParticleModuleRequired : public UParticleModule
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleSize.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleSize.h
@@ -1,12 +1,17 @@
 #pragma once
 
 #include "ParticleModuleSizeBase.h"
+#include "Distributions/DistributionVector.h"
 
 class UParticleModuleSize : public UParticleModuleSizeBase
 {
     DECLARE_CLASS(UParticleModuleSize, UParticleModuleSizeBase)
 
 public:
-    UParticleModuleSize() = default;
-    
+    UParticleModuleSize();
+
+    virtual void PostInitProperties() override;
+    virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;
+
+    FRawDistributionVector StartSize;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleVelocity.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleVelocity.h
@@ -9,7 +9,7 @@ class UParticleModuleVelocity : public UParticleModuleVelocityBase
     DECLARE_CLASS(UParticleModuleVelocity, UParticleModuleVelocityBase)
 
 public:
-    UParticleModuleVelocity() = default;
+    UParticleModuleVelocity();
     virtual void PostInitProperties() override;
 
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_LifeTime.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_LifeTime.cpp
@@ -1,0 +1,46 @@
+#include "ParticleModuleLifeTime.h"
+#include "UObject/Casts.h"
+#include "ParticleEmitterInstances.h"
+#include "Distributions/DistributionFloatUniform.h"
+#include "UObject/ObjectFactory.h"
+
+
+UParticleModuleLifeTime::UParticleModuleLifeTime()
+{
+    bEnabled = true;
+    bSpawnModule = true;
+    bUpdateModule = false;
+}
+
+/* LifeTime 값 초기화 */
+void UParticleModuleLifeTime::PostInitProperties()
+{
+    Super::PostInitProperties();
+    LifeTime.Distribution = FObjectFactory::ConstructObject<UDistributionFloatUniform>(this);
+    if (auto* Dist = Cast<UDistributionFloatUniform>(LifeTime.Distribution))
+    {
+        Dist->Min = 3.f;
+        Dist->Max = 10.f;
+    }
+}
+
+void UParticleModuleLifeTime::Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase)
+{
+    SPAWN_INIT;
+    float MaxLifeTime = LifeTime.GetValue(Owner->EmitterTime, Cast<UObject>(Owner->Component));
+
+    if (Particle.OneOverMaxLifetime > 0.0f)
+    {
+        // 다른 모듈이 이미 LifeTime을 설정한 경우, MaxLifeTime을 조정하여 OneOverMaxLifetime을 유지.
+        // 두 수명을 병합 : 더 작은 수명을 우선시하며 혼합
+        Particle.OneOverMaxLifetime = 1.0f / (MaxLifeTime + 1.f / Particle.OneOverMaxLifetime);
+    }
+    else
+    {
+        // 다른 모듈이 관여하지 않은 경우.
+        Particle.OneOverMaxLifetime = MaxLifeTime > 0.0f ? 1.0f / MaxLifeTime : 0.0f;
+    }
+
+    Particle.RelativeTime = Particle.RelativeTime > 1.0f ? Particle.RelativeTime : SpawnTime * Particle.OneOverMaxLifetime;
+
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Location.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Location.cpp
@@ -1,13 +1,34 @@
 #include "ParticleEmitterInstances.h"
 #include "ParticleModuleLocation.h"
+#include "Distributions/DistributionVectorUniform.h"
+#include "UObject/Casts.h"
+#include "UObject/ObjectFactory.h"
 
+
+UParticleModuleLocation::UParticleModuleLocation()
+{
+    bEnabled = true;
+    bSpawnModule = true;
+    bUpdateModule = false;
+}
+
+void UParticleModuleLocation::PostInitProperties()
+{
+    Super::PostInitProperties();
+    StartLocation.Distribution = FObjectFactory::ConstructObject<UDistributionVectorUniform>(this);
+    if (auto* Dist = Cast<UDistributionVectorUniform>(StartLocation.Distribution))
+    {
+        Dist->Min = FVector(-1.f, -1.f, -1.f);
+        Dist->Max = FVector(1.f, 1.f, 1.f);
+    }
+}
 
 void UParticleModuleLocation::Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase)
 {
     FBaseParticle& Particle = *ParticleBase;
 
     // 1) 로컬 오프셋 (ImGui에서 설정한 StartLocation) 가져오기
-    FVector LocationOffset = StartLocation;
+    FVector LocationOffset = StartLocation.GetValue(Owner->EmitterTime, Cast<UObject>(Owner->Component), 0);;
 
     // 2) 월드 -> 시뮬레이션 공간 변환 (EmitterToSimulation은 컴포넌트의 transform)
     LocationOffset = Owner->EmitterToSimulation.TransformPosition(LocationOffset);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Size.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Size.cpp
@@ -1,0 +1,34 @@
+#include "ParticleModuleSize.h"
+#include "UObject/Casts.h"
+#include "ParticleEmitterInstances.h"
+#include "Distributions/DistributionVectorUniform.h"
+#include "UObject/ObjectFactory.h"
+
+UParticleModuleSize::UParticleModuleSize()
+{
+    bEnabled = true;
+    bSpawnModule = true;
+    bUpdateModule = false;
+}
+
+
+void UParticleModuleSize::PostInitProperties()
+{
+    Super::PostInitProperties();
+    StartSize.Distribution = FObjectFactory::ConstructObject<UDistributionVectorUniform>(this);
+    if (auto* Dist = Cast<UDistributionVectorUniform>(StartSize.Distribution))
+    {
+        Dist->Min = FVector(1.f, 1.f, 1.f);
+        Dist->Max = FVector(1.f, 1.f, 1.f);
+    }
+}
+
+void UParticleModuleSize::Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase)
+{
+    SPAWN_INIT
+    FVector Size = StartSize.GetValue(Owner->EmitterTime, Cast<UObject>(Owner->Component), 0);
+    Particle.Size += Size;
+    Particle.BaseSize += Size;
+}
+
+

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Velocity.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Velocity.cpp
@@ -7,6 +7,12 @@
 #include "UObject/Casts.h"
 #include "UObject/ObjectFactory.h"
 
+UParticleModuleVelocity::UParticleModuleVelocity()
+{
+    bEnabled = true;
+    bSpawnModule = true;
+    bUpdateModule = false;
+}
 
 void UParticleModuleVelocity::PostInitProperties()
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
@@ -92,9 +92,9 @@ void UParticleSystemComponent::InitParticles()
             continue;
         }
 
-        // 1. 인스턴스 생성 
-        FParticleEmitterInstance* Inst = new FParticleEmitterInstance();
-        // 2. 사이즈 계산 + 풀 할당 - EmitterIndex는 internal에서 사용됨
+        // 인스턴스 생성/사이즈 계산 + 풀(Datacontainer) 할당
+        // 언리얼에서 EmitterIndex는 internal에서 사용됨
+        FParticleEmitterInstance* Inst = EmitterTemplate->CreateInstance(this);
         Inst->Init(this, EmitterIndex);
 
         EmitterInstances.Add(Inst);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/TypeData/ParticleModuleTypeDataMesh.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/TypeData/ParticleModuleTypeDataMesh.h
@@ -1,0 +1,13 @@
+#include "Particles/TypeData/ParticleModuleTypeDataBase.h"
+
+class UStaticMesh;
+
+class UParticleModuleTypeDataMesh : public UParticleModuleTypeDataBase
+{
+    DECLARE_CLASS(UParticleModuleTypeDataMesh, UParticleModuleTypeDataBase)
+
+public:
+    UParticleModuleTypeDataMesh() = default;
+
+    UStaticMesh* Mesh;
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/DepthPrePass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/DepthPrePass.cpp
@@ -33,7 +33,10 @@ void FDepthPrePass::PrepareRenderArr()
 void FDepthPrePass::Render(const std::shared_ptr<FEditorViewportClient>& Viewport)
 {
     PrepareRenderState(Viewport);
+    FStaticMeshRenderPass::PrepareRenderArr();
     FStaticMeshRenderPass::RenderAllStaticMeshes(Viewport);
+    FStaticMeshRenderPass::ClearRenderArr();
+
     FSkeletalMeshRenderPass::Render(Viewport);
     // 렌더 타겟 해제
     FStaticMeshRenderPass::Graphics->DeviceContext->OMSetRenderTargets(0, nullptr, nullptr);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/ParticleRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/ParticleRenderPass.cpp
@@ -274,7 +274,7 @@ void FParticleRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& V
             );
 
             BufferManager->UpdateStructuredBuffer("ParticleSpriteInstanceBuffer", SpriteVertices);
-            BufferManager->BindStructuredBufferSRV("ParticleSpriteInstanceBuffer", 0, EShaderStage::Vertex);
+            BufferManager->BindStructuredBufferSRV("ParticleSpriteInstanceBuffer", 60, EShaderStage::Vertex);
             Graphics->DeviceContext->DrawInstanced(
                                             /*VertexCountPerInstance=*/ 6,
                                             /*InstanceCount=*/ SpriteVertices.Num(),

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -848,6 +848,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\GameFramework\Pawn.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSystemComponent.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleEmitterInstances.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\TypeData\ParticleModuleTypeDataMesh.h" />
     <ClInclude Include="SoundManager.h" />
     <None Include="Shaders\EditorShaderConstants.hlsli">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -350,8 +350,9 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleEmitter.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleLODLevel.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules.cpp" />
-    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModuleLifeTime.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_Lifetime.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_Location.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_Size.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_Velocity.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSystem.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\TypeData\ParticleModuleTypeDataSprite.cpp" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -350,7 +350,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleEmitter.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleLODLevel.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules.cpp" />
-    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_Lifetime.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_LifeTime.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_Location.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_Size.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules_Velocity.cpp" />

--- a/EngineSIU/EngineSIU/Shaders/ParticleSpriteVertexShader.hlsl
+++ b/EngineSIU/EngineSIU/Shaders/ParticleSpriteVertexShader.hlsl
@@ -13,7 +13,7 @@ struct FParticleSpriteVertex
     float4 Color;
 };
 
-StructuredBuffer<FParticleSpriteVertex> InstanceBuffer : register(t0);
+StructuredBuffer<FParticleSpriteVertex> InstanceBuffer : register(t60);
 
 struct VS_Input 
 {


### PR DESCRIPTION
## 주요 변경사항

### Refactored
- EmitterInstance상속받는 Sprite, Mesh 인스턴스로 분리
- Component 단에서 초기화 시 instance별 emitterdata 다른 구조체로 쓰도록 정의 : 현재 fillreplay data 등은 sprite의 그것과 거의 동일

TODO
- Mesh용 inputlayout 적용
- particlerenderpass에서 typedatamodule자료형에 따라 분기
- staticemesh와 동일한 셰이더 적용