### PR TITLE
ParticleSystem 저장 및 World 적용 로직 추가.

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PropertyEditorPanel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PropertyEditorPanel.cpp
@@ -47,6 +47,7 @@
 #include "Animation/AnimationStateMachine.h"
 #include <Contents/PreviewAnimInstance.h>
 #include "Particles/ParticleSystemComponent.h"
+#include "Particles/ParticleSystem.h"
 
 #include "GameFramework/Actor.h"
 
@@ -1645,6 +1646,7 @@ void PropertyEditorPanel::RenderForParticleComponent(UParticleSystemComponent* P
 
         // 1. 현재 ParticleSystemComponent의 Template 이름 기준으로 초기 선택 인덱스 계산
         FString CurrentSystemName;
+        
         if (ParticleComponent->Template)
         {
             for (const auto& Pair : ParticleMap)
@@ -1701,6 +1703,7 @@ void PropertyEditorPanel::RenderForParticleComponent(UParticleSystemComponent* P
         ImGui::TreePop();
     }
 }
+
 void PropertyEditorPanel::RenderForMaterial(UStaticMeshComponent* StaticMeshComp)
 {
     if (StaticMeshComp->GetStaticMesh() == nullptr)

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PropertyEditorPanel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PropertyEditorPanel.cpp
@@ -1637,12 +1637,12 @@ void PropertyEditorPanel::RenderForParticleComponent(UParticleSystemComponent* P
         // 1) Get() 으로 매니저 참조 가져오기
         UAssetManager& AssetMgr = UAssetManager::Get();
 
-        // 2) 바로 Map 참조 선언과 초기화
-        auto& Map = AssetMgr.GetSavedParticleSystemMap();
+        // 2) 바로 ParticleMap 참조 선언과 초기화
+        auto& ParticleMap = AssetMgr.GetSavedParticleSystemMap();
 
         // 키 FString 목록 -> TArrtay<FString> 에 담기
         TArray<FString> ParticleSystemNames;
-        for (auto& Pair : Map)
+        for (auto& Pair : ParticleMap)
         {
             ParticleSystemNames.Add(Pair.Key);
         }
@@ -1676,7 +1676,7 @@ void PropertyEditorPanel::RenderForParticleComponent(UParticleSystemComponent* P
             // --- 5) 선택된 시스템을 컴포넌트에 적용 ---
             if (SelectedPSIndex >= 0 && SelectedPSIndex < ParticleSystemNames.Num())
             {
-                UParticleSystem* ChosenPS = Map[ParticleSystemNames[SelectedPSIndex]];
+                UParticleSystem* ChosenPS = ParticleMap[ParticleSystemNames[SelectedPSIndex]];
                 ParticleComponent->Template = ChosenPS;
             }
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/SubEditor/ParticleSystemViewerPanel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/SubEditor/ParticleSystemViewerPanel.cpp
@@ -144,20 +144,9 @@ void ParticleSystemViewerPanel::RenderEmitters()
             // SaveSystemName 을 이용해 실제 저장 처리
             FString Key(SaveSystemName); 
 
-            //// 1) Get() 으로 매니저 참조 가져오기
-            //UAssetManager& AssetMgr = UAssetManager::Get();
-            ////UAssetManager::Get().AddSavedParticle(Key, CurrentParticleSystem);
-
-            //// 2) 바로 Map 참조 선언과 초기화
-            //auto& Map = AssetMgr.SavedParticleSystemMap;
-
-            //Map.Emplace(Key, CurrentParticleSystem);
-
-            UParticleSystem* SystemPtr = CurrentParticleSystem;
-
+            UParticleSystem* SystemPtr = Cast<UParticleSystem>(CurrentParticleSystem->Duplicate(CurrentParticleSystem->GetOuter()));
             // Get() 이 반환하는 UAssetMaanger& 에 바로 호출
             UAssetManager::Get().AddSavedParticleSystem(Key, SystemPtr);
-   
             ImGui::CloseCurrentPopup();
         }
         ImGui::SameLine();
@@ -204,41 +193,16 @@ void ParticleSystemViewerPanel::RenderEmitters()
     // 4) 팝업 그리기
     if (ImGui::BeginPopup("Add Emitter Popup", ImGuiWindowFlags_AlwaysAutoResize))
     {
-        bool bIsSpriteEmitter = false;
         if (ImGui::Selectable("New Particle Sprite Emitter"))
         {
-            bIsSpriteEmitter = true;
+            CurrentParticleSystem->AddNewEmitterSprite();
 
-            DefaultEmitterIndex++;
-            UParticleEmitter* NewEmitter = CreateDefaultSpriteEmitter(DefaultEmitterIndex);
-
-            if (NewEmitter)
-            {
-                if (!CurrentParticleSystem)
-                {
-                    CurrentParticleSystem = new UParticleSystem();
-                    CurrentParticleSystemComponent->SetParticleSystem(CurrentParticleSystem);
-                }
-                CurrentParticleSystem->Emitters.Add(NewEmitter);
-            }
             ImGui::CloseCurrentPopup();
         }
         if (ImGui::Selectable("New Particle Mesh Emitter"))
         {
-            bIsSpriteEmitter = false;
-            
-            DefaultEmitterIndex++;
-            UParticleEmitter* NewEmitter = CreateDefaultMeshEmitter(DefaultEmitterIndex);
+            CurrentParticleSystem->AddNewEmitterMesh();
 
-            if (NewEmitter)
-            {
-                if (!CurrentParticleSystem)
-                {
-                    CurrentParticleSystem = new UParticleSystem();
-                    CurrentParticleSystemComponent->SetParticleSystem(CurrentParticleSystem);
-                }
-                CurrentParticleSystem->Emitters.Add(NewEmitter);
-            }
             ImGui::CloseCurrentPopup();
         }
         ImGui::EndPopup();
@@ -386,92 +350,6 @@ void ParticleSystemViewerPanel::RenderCurveEditor()
     ImGui::Begin("Curve Editor", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse);
     
     ImGui::End();
-}
-
-UParticleEmitter* ParticleSystemViewerPanel::CreateDefaultSpriteEmitter(int32 Index)
-{
-    // 1) Emitter 객체 생성
-    UParticleEmitter* NewEmitter = FObjectFactory::ConstructObject<UParticleEmitter>(CurrentParticleSystem);
-    std::string EmitterName = "SpriteEmitter_" + std::to_string(Index);
-    NewEmitter->EmitterName = EmitterName.c_str();
-    NewEmitter->ParticleSize = 20;
-
-    // LODLevel 0 생성 및 기본 설정
-    UParticleLODLevel* LOD0 = CreateDefaultLODLevel(NewEmitter);
-
-    LOD0->TypeDataModule = FObjectFactory::ConstructObject<UParticleModuleTypeDataSprite>(LOD0);
-    // LODLevel을 Emitter에 추가
-    NewEmitter->LODLevels.Add(LOD0);
-
-    return NewEmitter;
-}
-
-UParticleEmitter* ParticleSystemViewerPanel::CreateDefaultMeshEmitter(int32 Index)
-{
-    // 1) Emitter 객체 생성
-    UParticleEmitter* NewEmitter = FObjectFactory::ConstructObject<UParticleEmitter>(CurrentParticleSystem);
-    std::string EmitterName = "MeshEmitter_" + std::to_string(Index);
-    NewEmitter->EmitterName = EmitterName.c_str();
-    NewEmitter->ParticleSize = 20;
-
-    UParticleLODLevel* LOD0 = CreateDefaultLODLevel(NewEmitter);
-    LOD0->TypeDataModule = FObjectFactory::ConstructObject<UParticleModuleTypeDataMesh>(LOD0);
-
-    // 9) LODLevel을 Emitter에 추가
-    NewEmitter->LODLevels.Add(LOD0);
-
-    return NewEmitter;
-}
-
-UParticleLODLevel* ParticleSystemViewerPanel::CreateDefaultLODLevel(UParticleEmitter* Emitter)
-{
-    // -- 2) LODLevel 0 생성 및 기본 설정
-    UParticleLODLevel* LOD0 = FObjectFactory::ConstructObject<UParticleLODLevel>(Emitter);
-    LOD0->LODLevel = 0;
-    LOD0->bEnabled = true;
-
-    // -- 3) Required 모듈 (필수)
-    {
-        UParticleModuleRequired* OldReq = LOD0->RequiredModule;
-        UParticleModuleRequired* Req = FObjectFactory::ConstructObject<UParticleModuleRequired>(LOD0);
-        Req->EmitterOrigin = FVector::ZeroVector;
-        Req->EmitterRotation = FRotator::ZeroRotator;
-        LOD0->RequiredModule = Req;
-
-        TArray<UParticleModule*> Temp = LOD0->Modules;
-        Temp.RemoveSingle(OldReq);
-        LOD0->Modules.Empty();
-        LOD0->Modules.Add(Req);
-        LOD0->Modules.Append(Temp);
-    }
-
-    // -- 4) Spawn
-    {
-        UParticleModuleSpawn* Spawn = FObjectFactory::ConstructObject<UParticleModuleSpawn>(LOD0);
-        LOD0->Modules.Add(Spawn);
-    }
-    // -- 5) Lifetime
-    {
-        UParticleModuleLifeTime* Life = FObjectFactory::ConstructObject<UParticleModuleLifeTime>(LOD0);
-        LOD0->Modules.Add(Life);
-    }
-    // -- 6) Size
-    {
-        UParticleModuleSize* Size = FObjectFactory::ConstructObject<UParticleModuleSize>(LOD0);
-        LOD0->Modules.Add(Size);
-    }
-    // -- 7) Velocity
-    {
-        UParticleModuleVelocity* Vel = FObjectFactory::ConstructObject<UParticleModuleVelocity>(LOD0);
-        LOD0->Modules.Add(Vel);
-    }
-    // -- 8) Color
-    {
-        UParticleModuleColor* Color = FObjectFactory::ConstructObject<UParticleModuleColor>(LOD0);
-        LOD0->Modules.Add(Color);
-    }
-
-    return LOD0;
 }
 
 void ParticleSystemViewerPanel::RenderModuleItem(UParticleEmitter* Emitter, UParticleModule* Module)

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/SubEditor/ParticleSystemViewerPanel.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/SubEditor/ParticleSystemViewerPanel.h
@@ -38,14 +38,6 @@ private:
 
     void RenderAddModulePopup(UParticleEmitter* module);
     
-    // Test
-    UParticleEmitter* CreateDefaultEmitter(int32 Index);
-    UParticleEmitter* CreateDefaultEmitter(int32 Index, bool bIsSpriteEmitter);
-    UParticleEmitter* CreateDefaultSpriteEmitter(int32 Index);
-    UParticleEmitter* CreateDefaultMeshEmitter(int32 Index);
-
-    UParticleLODLevel* CreateDefaultLODLevel(UParticleEmitter* Emitter);
-
 private:
     float Width = 800, Height = 600;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/AssetManager.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/AssetManager.cpp
@@ -68,7 +68,7 @@ const TMap<FName, FAssetInfo>& UAssetManager::GetAssetRegistry()
 
 void UAssetManager::AddSavedParticleSystem(const FString& key, UParticleSystem*& system)
 {
-    SavedParticleSystemMap.Add(key, system);
+    SavedParticleSystemMap[key] = system;
 }
 
 bool UAssetManager::AddAsset(FString filePath)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleActor.cpp
@@ -18,63 +18,11 @@ void AParticleActor::PostSpawnInitialize()
     ParticleSystemComponent = AddComponent<UParticleSystemComponent>(FName("ParticleSystemComponent_0"));
     RootComponent = ParticleSystemComponent;
 
-    // -- 1) PS / Emitter / LOD 생성
-    UParticleSystem* PS = FObjectFactory::ConstructObject<UParticleSystem>(this);
-    UParticleEmitter* Emitter = FObjectFactory::ConstructObject<UParticleEmitter>(nullptr);
-    UParticleLODLevel* LOD = FObjectFactory::ConstructObject<UParticleLODLevel>(nullptr);
-
-    // -- 2) Required module
-    UParticleModuleRequired* ReqMod = FObjectFactory::ConstructObject<UParticleModuleRequired>(nullptr);
-    ReqMod->bEnabled = true;
-    ReqMod->EmitterDuration = 3.0f;
-    ReqMod->SpawnRate = 10.0f / ReqMod->EmitterDuration;  // 3초의 Emitter Cycle동안 1개의 파티클 생성
-
-    // TypeDataModule 생성 및 세팅 (현재는 Sprite Type이라고 가정하고 일단 아래처럼 구현)
-    UParticleModuleTypeDataSprite* SpriteTypeData = FObjectFactory::ConstructObject<UParticleModuleTypeDataSprite>(nullptr);
-
-    /* [NOTE!!!] 모든 Module은 생성자에서 bEnabled = true */
-    // Location 모듈 생성
-    UParticleModuleLocation* LocMod = FObjectFactory::ConstructObject<UParticleModuleLocation>(nullptr);
-    //LocMod->StartLocation = FVector::ZeroVector;  // 하드코딩
-
-    // Velocity 모듈 생성
-    UParticleModuleVelocity* VelMod = FObjectFactory::ConstructObject<UParticleModuleVelocity>(nullptr);
-    //VelMod->StartVelocity = FVector(0.f, 0.f, 1.f);  // 하드코딩
-
-    // Lifetime 모듈 생성
-    UParticleModuleLifeTime* LifeMod = FObjectFactory::ConstructObject<UParticleModuleLifeTime>(nullptr);
-
-
-    // TODO : (원한다면 파생 클래스로 교체: UParticleModuleTypeDataSprite 등)
-
-    // 생성한 객체들 서로 연결
-    PS->Emitters.Add(Emitter);
-    Emitter->LODLevels.Add(LOD);
-
-    LOD->RequiredModule = ReqMod;
-    LOD->TypeDataModule = SpriteTypeData;
-
-    LOD->Modules = { ReqMod, SpriteTypeData, LocMod, VelMod, LifeMod };
-    LOD->SpawnModules = { ReqMod, SpriteTypeData, LocMod, VelMod, LifeMod };  // Spawn 시에만 위치+속도 세팅
-    LOD->UpdateModules = { SpriteTypeData };
-
-    // Offset/Size 계산
-    PS->BuildEmitters();
-
-    // 컴포넌트에 템플릿 연결 + 초기화
-    ParticleSystemComponent->Template = PS;
     ParticleSystemComponent->InitializeSystem();
 
     // 하드코딩된 초기 위치/속도 세팅
     ParticleSystemComponent->InitialLocationHardcoded = FVector::ZeroVector;
     ParticleSystemComponent->InitialVelocityHardcoded = FVector(0.f, 0.f, 1.f);
-
-    UE_LOG(ELogLevel::Error,
-        TEXT("Initialized: Duration=%.1f, Rate=%.1f, Mods=%d"),
-        ReqMod->EmitterDuration,
-        ReqMod->SpawnRate,
-        LOD->Modules.Num()
-    );
 }
 
 UObject* AParticleActor::Duplicate(UObject* InOuter)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
@@ -5,6 +5,8 @@
 #include "ParticleModule.h"
 #include "TypeData/ParticleModuleTypeDataMesh.h"
 #include "ParticleEmitterInstances.h"
+#include "UObject/Casts.h"
+#include "UObject/ObjectFactory.h"
 
 UParticleLODLevel* UParticleEmitter::GetLODLevel(int32 LODLevel)
 {
@@ -14,6 +16,51 @@ UParticleLODLevel* UParticleEmitter::GetLODLevel(int32 LODLevel)
     }
 
     return LODLevels[LODLevel];
+}
+
+void UParticleEmitter::PostInitProperties()
+{
+    Super::PostInitProperties();
+    // LODLevel 초기화
+    // LODLevel 초기화
+    LODLevels.Empty();
+
+    // 기본 LODLevel 추가
+    for (int32 i = 0; i < 1; ++i)
+    {
+        UParticleLODLevel* NewLODLevel = FObjectFactory::ConstructObject<UParticleLODLevel>(this);
+        if (NewLODLevel)
+        {
+            NewLODLevel->LODLevel = i;
+            LODLevels.Add(NewLODLevel);
+        }
+    }
+}
+
+UObject* UParticleEmitter::Duplicate(UObject* InOuter)
+{
+    UParticleEmitter* NewEmitter = Cast<UParticleEmitter>(Super::Duplicate(InOuter));
+    if (NewEmitter)
+    {
+        NewEmitter->ParticleSize = ParticleSize;
+        NewEmitter->InitialAllocationCount = InitialAllocationCount;
+        NewEmitter->ReqInstanceBytes = ReqInstanceBytes;
+        // LODLevel 복사
+        for (int32 i = 0; i < LODLevels.Num(); ++i)
+        {
+            UParticleLODLevel* LODLevel = LODLevels[i];
+            if (LODLevel)
+            {
+                UParticleLODLevel* NewLODLevel = Cast<UParticleLODLevel>(LODLevel->Duplicate(NewEmitter));
+                if (NewLODLevel)
+                {
+                    NewEmitter->LODLevels.Add(NewLODLevel);
+                }
+            }
+        }
+    }
+    return NewEmitter;
+    
 }
 
 void UParticleEmitter::Build()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
@@ -46,17 +46,10 @@ UObject* UParticleEmitter::Duplicate(UObject* InOuter)
         NewEmitter->InitialAllocationCount = InitialAllocationCount;
         NewEmitter->ReqInstanceBytes = ReqInstanceBytes;
         // LODLevel 복사
+        NewEmitter->LODLevels.SetNum(LODLevels.Num());
         for (int32 i = 0; i < LODLevels.Num(); ++i)
         {
-            UParticleLODLevel* LODLevel = LODLevels[i];
-            if (LODLevel)
-            {
-                UParticleLODLevel* NewLODLevel = Cast<UParticleLODLevel>(LODLevel->Duplicate(NewEmitter));
-                if (NewLODLevel)
-                {
-                    NewEmitter->LODLevels.Add(NewLODLevel);
-                }
-            }
+            NewEmitter->LODLevels[i] = Cast<UParticleLODLevel>(LODLevels[i]->Duplicate(NewEmitter));
         }
     }
     return NewEmitter;
@@ -71,7 +64,14 @@ void UParticleEmitter::Build()
     {
         /* Cache particle size/offset data for all LOD Levels */
         CacheEmitterModuleInfo();
-
+        for (UParticleLODLevel* LodLevel : LODLevels)
+        {
+            if (LodLevel)
+            {
+                LodLevel->UpdateModuleLists();
+            }
+        }
+        
         UE_LOG(ELogLevel::Error, TEXT("ParticleSize=%d  ReqInstanceBytes=%d Modules=%d"),
             ParticleSize, ReqInstanceBytes, ModulesNeedingInstanceData.Num());
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.h
@@ -44,17 +44,18 @@ class UParticleEmitter : public UObject
 
 public:
     UParticleEmitter() = default;
+    virtual void PostInitProperties() override;
+    virtual UObject* Duplicate(UObject* InOuter) override;
     void Build();
     FParticleEmitterInstance* CreateInstance(UParticleSystemComponent* InComponent);
     void CacheEmitterModuleInfo();
     void PostLoad();
 
-
     UParticleLODLevel* GetCurrentLODLevel(FParticleEmitterInstance* Instance) const;
     UParticleLODLevel* GetLODLevel(int32 LODLevel);
 
     FName EmitterName;
-    int32 ParticleSize;
+    int32 ParticleSize = 1;
     int32 InitialAllocationCount = 100;
     int32 ReqInstanceBytes;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.cpp
@@ -4,6 +4,74 @@
 #include "UObject/ObjectFactory.h"
 #include "UObject/Casts.h"
 
+#include "Particles/ParticleModuleRequired.h"
+#include "Particles/ParticleModuleSpawn.h"
+#include "ParticleModuleSize.h"
+#include "ParticleModuleLifeTime.h"
+#include "ParticleModuleVelocity.h"
+#include "ParticleModuleColor.h"
+#include "ParticleModuleLocation.h"
+#include "TypeData/ParticleModuleTypeDataSprite.h"
+
+void UParticleLODLevel::PostInitProperties()
+{
+    Super::PostInitProperties();
+    // LODLevel 초기화
+    LODLevel = 0;
+    bEnabled = true;
+    PeakActiveParticles = 0;
+    // 모듈 초기화
+    Modules.Empty();
+    SpawnModules.Empty();
+    UpdateModules.Empty();
+    TypeDataModule = nullptr;
+    RequiredModule = nullptr;
+    SpawnModule = nullptr;
+
+    // 기본 모듈 추가
+    RequiredModule = FObjectFactory::ConstructObject<UParticleModuleRequired>(this);
+    Modules.Add(RequiredModule);
+
+    SpawnModule = FObjectFactory::ConstructObject<UParticleModuleSpawn>(this);
+    Modules.Add(SpawnModule);
+
+    TypeDataModule = FObjectFactory::ConstructObject<UParticleModuleTypeDataSprite>(this);
+    Modules.Add(TypeDataModule);
+
+    Modules.Add(FObjectFactory::ConstructObject<UParticleModuleLocation>(this));
+    Modules.Add(FObjectFactory::ConstructObject<UParticleModuleVelocity>(this));
+    Modules.Add(FObjectFactory::ConstructObject<UParticleModuleLifeTime>(this));
+    Modules.Add(FObjectFactory::ConstructObject<UParticleModuleSize>(this));
+    Modules.Add(FObjectFactory::ConstructObject<UParticleModuleColor>(this));
+
+    UpdateModuleLists();
+}
+
+UObject* UParticleLODLevel::Duplicate(UObject* InOuter)
+{
+    UParticleLODLevel* NewLODLevel = Cast<UParticleLODLevel>(Super::Duplicate(InOuter));
+    if (NewLODLevel)
+    {
+        NewLODLevel->LODLevel = LODLevel;
+        NewLODLevel->bEnabled = bEnabled;
+        NewLODLevel->PeakActiveParticles = PeakActiveParticles;
+        // LODLevel의 모듈 복사
+        for (int32 i = 0; i < Modules.Num(); ++i)
+        {
+            UParticleModule* Module = Modules[i];
+            if (Module)
+            {
+                UParticleModule* NewModule = Cast<UParticleModule>(Module->Duplicate(NewLODLevel));
+                if (NewModule)
+                {
+                    NewLODLevel->Modules.Add(NewModule);
+                }
+            }
+        }
+    }
+    return NewLODLevel;
+}
+
 // TODO : 현재 미사용인 함수, 추후 PostLoad() 등에서 호출 필요
 // SpawnModules  :FParticleEmitterInstance::SpawnParticles 에서 쓰임
 // UpdateModules :FParticleEmitterInstance::Tick_ModuleUpdate에서 쓰임

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.cpp
@@ -43,8 +43,6 @@ void UParticleLODLevel::PostInitProperties()
     Modules.Add(FObjectFactory::ConstructObject<UParticleModuleLifeTime>(this));
     Modules.Add(FObjectFactory::ConstructObject<UParticleModuleSize>(this));
     Modules.Add(FObjectFactory::ConstructObject<UParticleModuleColor>(this));
-
-    UpdateModuleLists();
 }
 
 UObject* UParticleLODLevel::Duplicate(UObject* InOuter)
@@ -56,16 +54,12 @@ UObject* UParticleLODLevel::Duplicate(UObject* InOuter)
         NewLODLevel->bEnabled = bEnabled;
         NewLODLevel->PeakActiveParticles = PeakActiveParticles;
         // LODLevel의 모듈 복사
+        NewLODLevel->Modules.SetNum(Modules.Num());
         for (int32 i = 0; i < Modules.Num(); ++i)
         {
-            UParticleModule* Module = Modules[i];
-            if (Module)
+            if (Modules[i])
             {
-                UParticleModule* NewModule = Cast<UParticleModule>(Module->Duplicate(NewLODLevel));
-                if (NewModule)
-                {
-                    NewLODLevel->Modules.Add(NewModule);
-                }
+                NewLODLevel->Modules[i] = Cast<UParticleModule>(Modules[i]->Duplicate(NewLODLevel));
             }
         }
     }
@@ -79,6 +73,9 @@ void UParticleLODLevel::UpdateModuleLists()
 {
     UParticleModule* Module;
     int32 TypeDataModuleIndex = -1;
+
+    SpawnModules.Empty();
+    UpdateModules.Empty();
 
     for (int32 i = 0; i < Modules.Num(); i++)
     {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.h
@@ -14,6 +14,8 @@ class UParticleLODLevel : public UObject
 
 public:
     UParticleLODLevel() = default;
+    virtual void PostInitProperties() override;
+    virtual UObject* Duplicate(UObject* InOuter) override;
     virtual void UpdateModuleLists();
 
     void AddModule(UClass* ModuleClass);
@@ -34,8 +36,9 @@ public:
 
     UParticleModuleTypeDataBase* TypeDataModule;
 
-
     UParticleModuleRequired* RequiredModule;
     UParticleModuleSpawn* SpawnModule;
+
+    bool bSpriteTypeData = true;
    
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModule.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModule.h
@@ -38,6 +38,8 @@ class UParticleModule : public UObject
 
 public:
     UParticleModule() = default;
+    virtual void PostInitProperties() override;
+    virtual UObject* Duplicate(UObject* InOuter) override;
 
 public:
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLifeTime.h
@@ -10,6 +10,7 @@ class UParticleModuleLifeTime : public UParticleModuleLifeTimeBase
 
 public:
     UParticleModuleLifeTime();
+    virtual UObject* Duplicate(UObject* InOuter) override;
 
     UPROPERTY(EditAnywhere, FRawDistributionFloat, LifeTime)
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLocation.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleLocation.h
@@ -9,10 +9,11 @@ class UParticleModuleLocation : public UParticleModuleLocationBase
 
 public:
     UParticleModuleLocation();
+    virtual UObject* Duplicate(UObject* InOuter) override;
+
     virtual void PostInitProperties() override;
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;
 
 
     FRawDistributionVector StartLocation;
-
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleRequired.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleRequired.h
@@ -35,6 +35,7 @@ class UParticleModuleRequired : public UParticleModule
 
 public:
     UParticleModuleRequired();
+    virtual UObject* Duplicate(UObject* InOuter) override;
 
 public:
     UPROPERTY(EditAnywhere, UMaterial*, Material)
@@ -53,9 +54,9 @@ public:
 
     // 초당 생성할 파티클 수
     // TODO : RawDistribution 으로 바꿔야 함
+    float EmitterDuration;
     float SpawnRate;
 
-    float EmitterDuration;
 
     virtual void PostInitProperties() override;
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleSize.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleSize.h
@@ -9,6 +9,8 @@ class UParticleModuleSize : public UParticleModuleSizeBase
 
 public:
     UParticleModuleSize();
+    virtual UObject* Duplicate(UObject* InOuter) override;
+
 
     virtual void PostInitProperties() override;
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleVelocity.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleVelocity.h
@@ -10,6 +10,8 @@ class UParticleModuleVelocity : public UParticleModuleVelocityBase
 
 public:
     UParticleModuleVelocity();
+    virtual UObject* Duplicate(UObject* InOuter) override;
+
     virtual void PostInitProperties() override;
 
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules.cpp
@@ -1,11 +1,37 @@
 #include "ParticleModule.h"
 #include "TypeData/ParticleModuleTypeDataBase.h"
 
+#include "UObject/Casts.h"
+
 #include "ParticleModuleLifeTimeBase.h"
 #include "ParticleModuleLifeTime.h"
 #include "ParticleModuleColorBase.h"
 #include "ParticleModuleColor.h"
 
+
+void UParticleModule::PostInitProperties()
+{
+    bEnabled = true;
+}
+
+UObject* UParticleModule::Duplicate(UObject* InOuter)
+{
+    UParticleModule* NewModule = Cast<UParticleModule>(Super::Duplicate(InOuter));
+    if (NewModule)
+    {
+        NewModule->bEnabled = bEnabled;
+        NewModule->bSpawnModule = bSpawnModule;
+        NewModule->bUpdateModule = bUpdateModule;
+        NewModule->bFinalUpdateModule = bFinalUpdateModule;
+        NewModule->bUpdateForGPUEmitter = bUpdateForGPUEmitter;
+        NewModule->bCurvesAsColor = bCurvesAsColor;
+        NewModule->b3DDrawMode = b3DDrawMode;
+        NewModule->bSupported3DDrawMode = bSupported3DDrawMode;
+        NewModule->EditorColor = EditorColor;
+        NewModule->bEditable = bEditable;
+    }
+    return NewModule;
+}
 
 void UParticleModule::Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase)
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_LifeTime.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_LifeTime.cpp
@@ -12,6 +12,16 @@ UParticleModuleLifeTime::UParticleModuleLifeTime()
     bUpdateModule = false;
 }
 
+UObject* UParticleModuleLifeTime::Duplicate(UObject* InOuter)
+{
+    UParticleModuleLifeTime* NewModule = Cast<UParticleModuleLifeTime>(Super::Duplicate(InOuter));
+    if (NewModule)
+    {
+        NewModule->LifeTime = LifeTime;
+    }
+    return NewModule;
+}
+
 /* LifeTime 값 초기화 */
 void UParticleModuleLifeTime::PostInitProperties()
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Location.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Location.cpp
@@ -12,6 +12,16 @@ UParticleModuleLocation::UParticleModuleLocation()
     bUpdateModule = false;
 }
 
+UObject* UParticleModuleLocation::Duplicate(UObject* InOuter)
+{
+    UParticleModuleLocation* NewModule = Cast<UParticleModuleLocation>(Super::Duplicate(InOuter));
+    if (NewModule)
+    {
+        NewModule->StartLocation = StartLocation;
+    }
+    return NewModule;
+}
+
 void UParticleModuleLocation::PostInitProperties()
 {
     Super::PostInitProperties();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Required.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Required.cpp
@@ -2,11 +2,32 @@
 #include "ParticleModuleRequired.h"
 #include "UObject/ObjectFactory.h"
 
+#include "UObject/Casts.h"
+
 UParticleModuleRequired::UParticleModuleRequired()
 {
     bEnabled = true;
     bSpawnModule = true;
     bUpdateModule = false;
+}
+
+UObject* UParticleModuleRequired::Duplicate(UObject* InOuter)
+{
+    UParticleModuleRequired* NewModule = Cast<UParticleModuleRequired>(Super::Duplicate(InOuter));
+    if (NewModule)
+    {
+        NewModule->Material = Material;
+        NewModule->EmitterOrigin = EmitterOrigin;
+        NewModule->EmitterRotation = EmitterRotation;
+        NewModule->SortMode = SortMode;
+        NewModule->bUseLocalSpace = bUseLocalSpace;
+        NewModule->bKillOnDeactivate = bKillOnDeactivate;
+        NewModule->bKillOnCompleted = bKillOnCompleted;
+        NewModule->SpawnRate = SpawnRate;
+        NewModule->EmitterDuration = EmitterDuration;
+    }
+    return NewModule;
+    
 }
 
 void UParticleModuleRequired::PostInitProperties()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Size.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Size.cpp
@@ -11,6 +11,16 @@ UParticleModuleSize::UParticleModuleSize()
     bUpdateModule = false;
 }
 
+UObject* UParticleModuleSize::Duplicate(UObject* InOuter)
+{
+    UParticleModuleSize* NewModule = Cast<UParticleModuleSize>(Super::Duplicate(InOuter));
+    if (NewModule)
+    {
+        NewModule->StartSize = StartSize;
+    }
+    return NewModule;
+}
+
 
 void UParticleModuleSize::PostInitProperties()
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Velocity.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules_Velocity.cpp
@@ -14,6 +14,17 @@ UParticleModuleVelocity::UParticleModuleVelocity()
     bUpdateModule = false;
 }
 
+UObject* UParticleModuleVelocity::Duplicate(UObject* InOuter)
+{
+    UParticleModuleVelocity* NewModule = Cast<UParticleModuleVelocity>(Super::Duplicate(InOuter));
+    if (NewModule)
+    {
+        NewModule->StartVelocity = StartVelocity;
+        NewModule->StartVelocityRadial = StartVelocityRadial;
+    }
+    return NewModule;
+}
+
 void UParticleModuleVelocity::PostInitProperties()
 {
     StartVelocity.Distribution = FObjectFactory::ConstructObject<UDistributionVectorUniform>(this);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
@@ -23,17 +23,14 @@ UObject* UParticleSystem::Duplicate(UObject* InOuter)
     UParticleSystem* NewParticleSystem = Cast<UParticleSystem>(Super::Duplicate(InOuter));
     if (NewParticleSystem)
     {
+        NewParticleSystem->Emitters.SetNum(Emitters.Num());
+        
         // Emitters 복사
         for (int32 i = 0; i < Emitters.Num(); ++i)
         {
-            UParticleEmitter* Emitter = Emitters[i];
-            if (Emitter)
+            if (Emitters[i])
             {
-                UParticleEmitter* NewEmitter = Cast<UParticleEmitter>(Emitter->Duplicate(NewParticleSystem));
-                if (NewEmitter)
-                {
-                    NewParticleSystem->Emitters.Add(NewEmitter);
-                }
+                NewParticleSystem->Emitters[i] = Cast<UParticleEmitter>(Emitters[i]->Duplicate(NewParticleSystem));
             }
         }
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
@@ -1,6 +1,44 @@
 #include "ParticleSystem.h"
 
 #include "ParticleEmitter.h"
+#include "ParticleLODLevel.h"
+#include "UObject/ObjectFactory.h"
+#include "UObject/Casts.h"
+
+#include "TypeData/ParticleModuleTypeDataSprite.h"
+#include "TypeData/ParticleModuleTypeDataMesh.h"
+
+void UParticleSystem::PostInitProperties()
+{
+    Super::PostInitProperties();
+    // Emitters 초기화
+    Emitters.Empty();
+    Emitters.Add(FObjectFactory::ConstructObject<UParticleEmitter>(this));
+
+    BuildEmitters();
+}
+
+UObject* UParticleSystem::Duplicate(UObject* InOuter)
+{
+    UParticleSystem* NewParticleSystem = Cast<UParticleSystem>(Super::Duplicate(InOuter));
+    if (NewParticleSystem)
+    {
+        // Emitters 복사
+        for (int32 i = 0; i < Emitters.Num(); ++i)
+        {
+            UParticleEmitter* Emitter = Emitters[i];
+            if (Emitter)
+            {
+                UParticleEmitter* NewEmitter = Cast<UParticleEmitter>(Emitter->Duplicate(NewParticleSystem));
+                if (NewEmitter)
+                {
+                    NewParticleSystem->Emitters.Add(NewEmitter);
+                }
+            }
+        }
+    }
+    return NewParticleSystem;
+}
 
 void UParticleSystem::BuildEmitters()
 {
@@ -12,4 +50,27 @@ void UParticleSystem::BuildEmitters()
             Emitter->Build();
         }
     }
+}
+
+void UParticleSystem::AddNewEmitterSprite()
+{
+    UParticleEmitter* NewEmitter = FObjectFactory::ConstructObject<UParticleEmitter>(this);
+    Emitters.Add(NewEmitter);
+    NewEmitter->Build();
+    NewEmitter->EmitterName = FName("SpriteEmitter_" + std::to_string(Emitters.Num()));
+
+}
+
+void UParticleSystem::AddNewEmitterMesh()
+{
+    UParticleEmitter* NewEmitter = FObjectFactory::ConstructObject<UParticleEmitter>(this);
+    Emitters.Add(NewEmitter);
+    NewEmitter->Build();
+    NewEmitter->EmitterName = FName("MeshEmitter_" + std::to_string(Emitters.Num()));
+    UParticleModuleTypeDataMesh* TypeDataModule = FObjectFactory::ConstructObject<UParticleModuleTypeDataMesh>(NewEmitter);
+    if (NewEmitter->LODLevels[0]->TypeDataModule)
+    {
+        NewEmitter->LODLevels[0]->RemoveModule(NewEmitter->LODLevels[0]->TypeDataModule);
+    }
+    NewEmitter->LODLevels[0]->AddModule(UParticleModuleTypeDataMesh::StaticClass());
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
@@ -11,6 +11,9 @@ class UParticleSystem : public UObject // UE는 UFXSystemAsset을 상속. 불필
 
 public:
     UParticleSystem() = default;
+    virtual void PostInitProperties() override;
+    virtual UObject* Duplicate(UObject* InOuter) override;
+
     void BuildEmitters();
 
     //virtual void PostLoad();
@@ -18,5 +21,7 @@ public:
     // 에디터에서 생성한 UParticleEmitter들
     TArray<UParticleEmitter*> Emitters;
 
+    void AddNewEmitterSprite();
+    void AddNewEmitterMesh();
 
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
@@ -83,7 +83,7 @@ void UParticleSystemComponent::ResetParticles()
 void UParticleSystemComponent::InitParticles()
 {
     /* 반드시 호출해야 Inst->Init에서 올바른 값을 참조 (SpriteTemplate의 모든 변수) */
-    Template->BuildEmitters();
+    //Template->BuildEmitters();
 
     ResetParticles();
 
@@ -228,6 +228,7 @@ void UParticleSystemComponent::SetTemplate(class UParticleSystem* NewTemplate)
     if (Template != NewTemplate)
     {
         Template = NewTemplate;
+        Template->BuildEmitters();
         InitializeSystem();         // 내부에서 InitParticles() 호출
     }
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.cpp
@@ -8,6 +8,12 @@
 #include "sol/sol.hpp"
 #include "World/World.h"
 
+void UParticleSystemComponent::PostInitProperties()
+{
+    Super::PostInitProperties();
+    Template = FObjectFactory::ConstructObject<UParticleSystem>(this);
+}
+
 void UParticleSystemComponent::TickComponent(float DeltaTime)
 {
     Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.h
@@ -13,6 +13,7 @@ class UParticleSystemComponent : public UPrimitiveComponent // UE는 UFXSystemCo
 
 public:
     UParticleSystemComponent() = default;
+    virtual void PostInitProperties() override;
     virtual void TickComponent(float DeltaTime) override;
     virtual void FinalizeTickComponent();
 


### PR DESCRIPTION
## ParticleSystem 저장 후 World에서 적용 로직 추가.

- ParticleSystem 복제를 위해 ParticleActor 생성 시 잡힌 로직 내부 처리로 변경.
- ParticleViewer에서 Save시 AssetManager에 복제 저장 되도록 변경.
- 저장된 ParticleSystem MainWorld에서 생성된 파티클 시스템에 적용 가능.

